### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,14 @@
 Changes for each release are listed in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) for its releases.
+
+## v0.1.0 (2024-09-07)
+
+[Full Changelog](https://github.com/main-branch/simplecov-rspec/compare/9fe828c..v0.1.0)
+
+Changes:
+
+* 93d7004 Add RSpec HTML formatter for CI build
+* 94f5a80 Configure RSpec to run turnip tests when run from rake
+* b3bf845 Use SimpleCov LCov formatter in the CI build
+* 9fe828c Initial revision


### PR DESCRIPTION
# Release PR

## v0.1.0 (2024-09-07)

[Full Changelog](https://github.com/main-branch/simplecov-rspec/compare/9fe828c..v0.1.0)

Changes:

* 93d7004 Add RSpec HTML formatter for CI build
* 94f5a80 Configure RSpec to run turnip tests when run from rake
* b3bf845 Use SimpleCov LCov formatter in the CI build
* 9fe828c Initial revision
