### PR TITLE
Move CI build using Ruby head to a different workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,18 +11,15 @@ jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
-    continue-on-error: ${{ matrix.experimental == 'Yes' }}
+    continue-on-error: true
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", head]
+        ruby: ["3.1", "3.2", "3.3"]
         operating-system: [ubuntu-latest]
-        experimental: [No]
         include:
           - ruby: "3.1"
             operating-system: windows-latest
-          - ruby: head
-            operating-system: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -36,6 +33,25 @@ jobs:
 
       - name: Run rake
         run: bundle exec rake
+
+  experimental:
+    name: Experimental builds
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'  # Only run if on main branch
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install gh -y
+
+      - name: Authenticate with GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Trigger Experimental Workflow
+        run: gh workflow run experimental_continuous_integration.yml
 
   coverage:
     needs: [build]

--- a/.github/workflows/experimental_continuous_integration.yml
+++ b/.github/workflows/experimental_continuous_integration.yml
@@ -1,0 +1,29 @@
+name: CI Build for Experimental Rubies
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.operating-system }}
+    continue-on-error: true
+
+    strategy:
+      matrix:
+        include:
+          - ruby: head
+            operating-system: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run rake
+        run: bundle exec rake


### PR DESCRIPTION
This pull request moves the CI build using Ruby head to a separate workflow. The previous workflow included experimental builds, but now the experimental builds are triggered separately using a repository dispatch event. This change ensures that the experimental builds can be triggered independently and allows for better organization of the CI workflows.