### PR TITLE
Allow the CI build to be manually triggered

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [main]
 
+  workflow_dispatch:
+
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}


### PR DESCRIPTION
Allow the build to be manually triggered in case there are problems with dependencies in the future.