### PR TITLE
Add Semver PR Label workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Continuous Integration
 
 on:
   push:

--- a/.github/workflows/experimental_continuous_integration.yml
+++ b/.github/workflows/experimental_continuous_integration.yml
@@ -1,4 +1,4 @@
-name: CI Build for Experimental Rubies
+name: Experimental Rubies
 
 on:
   workflow_dispatch
@@ -10,6 +10,7 @@ jobs:
     continue-on-error: true
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - ruby: head

--- a/.github/workflows/semver_pr_label.yml
+++ b/.github/workflows/semver_pr_label.yml
@@ -1,0 +1,23 @@
+name: Semver PR Label
+
+on:
+  pull_request:
+    branches: [main]
+
+    # This workflow will trigger when pull requests to the main branch are opened,
+    # synchronize, reopened, labeled, or unlabeled.
+
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  semver_pr_label:
+    name: Semver PR Label
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check that a semver label is present on the PR
+        if: github.event_name == 'pull_request'
+        uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: major-change,minor-change,patch-change,internal-change
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new workflow called "Semver PR Label" that will trigger when pull requests to the main branch are opened, synchronized, reopened, labeled, or unlabeled. The workflow checks that a semver label is present on the PR and uses the "pull-request-label-checker" Docker image for this purpose.