### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Changes for each release are listed in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/) for its releases.
 
+## v0.2.1 (2024-09-10)
+
+[Full Changelog](https://github.com/main-branch/simplecov-rspec/compare/v0.2.0..v0.2.1)
+
+Changes since v0.2.0:
+
+* d714b58 Simplify how the experimental ruby builds are triggered
+* de79d66 Use a reusable workflow for the Semver PR label check
+* d29ecac Add Semver PR Label workflow
+* 0fed875 Update the version of code climate test coverage reporter
+
 ## v0.2.0 (2024-09-08)
 
 [Full Changelog](https://github.com/main-branch/simplecov-rspec/compare/v0.1.0..v0.2.0)

--- a/lib/simplecov-rspec/version.rb
+++ b/lib/simplecov-rspec/version.rb
@@ -3,6 +3,6 @@
 module Simplecov
   class Rspec
     # This gem's version
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
# Release PR

## v0.2.1 (2024-09-10)

[Full Changelog](https://github.com/main-branch/simplecov-rspec/compare/v0.2.0..v0.2.1)

Changes since v0.2.0:

* d714b58 Simplify how the experimental ruby builds are triggered
* de79d66 Use a reusable workflow for the Semver PR label check
* d29ecac Add Semver PR Label workflow
* 0fed875 Update the version of code climate test coverage reporter
