### PR TITLE
Change simplecov from a development dependency to a runtime dependency

### DIFF
--- a/simplecov-rspec.gemspec
+++ b/simplecov-rspec.gemspec
@@ -37,13 +37,14 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'simplecov', '~> 0.22'
+
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 1.4'
+  spec.add_development_dependency 'create_github_release', '~> 1.5'
   spec.add_development_dependency 'fuubar', '~> 2.5'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
-  spec.add_development_dependency 'rubocop', '~> 1.64'
-  spec.add_development_dependency 'simplecov', '~> 0.22'
+  spec.add_development_dependency 'rubocop', '~> 1.66'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
   spec.add_development_dependency 'turnip', '~> 4.4'
 


### PR DESCRIPTION
This pull request updates the gemspec file to change the dependency on simplecov from a development dependency to a runtime dependency. This is needed because, technically, it is both a runtime and development dependency.

Additionally, it updates the version of create_github_release to 1.5 and rubocop to 1.66 as development dependencies.