### PR TITLE
Update minimal Ruby version to 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
 
   # RuboCop enforces rules depending on the oldest version of Ruby which
   # your project supports:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 Gemspec/DevelopmentDependencies:
   Enabled: false

--- a/simplecov-rspec.gemspec
+++ b/simplecov-rspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.homepage = 'https://github.com/main-branch/simplecov-rspec'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 

--- a/spec/simplecov-rspec_spec.rb
+++ b/spec/simplecov-rspec_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe SimpleCov::RSpec do
     let(:simplecov_module) { double('SimpleCov') }
 
     it 'should call SimpleCov.start' do
-      subject = described_class.new(simplecov_module: simplecov_module)
+      subject = described_class.new(simplecov_module:)
       expected_hook_proc = subject.send(:at_exit_hook).to_proc
       expect(simplecov_module).to receive(:at_exit) do |&block|
         # Verify that the block passed to #at_exit is equivalent to the expected hook proc
@@ -153,7 +153,7 @@ RSpec.describe SimpleCov::RSpec do
     context 'when a start_config_block is set' do
       it 'should call SimpleCov.start with that block' do
         start_config_block = proc {}
-        subject = described_class.new(simplecov_module: simplecov_module, &start_config_block)
+        subject = described_class.new(simplecov_module:, &start_config_block)
         allow(simplecov_module).to receive(:at_exit)
         expect(simplecov_module).to receive(:start) do |&block|
           expect(block.binding.receiver).to eq(start_config_block.binding.receiver)


### PR DESCRIPTION
This pull request updates the minimal Ruby version to 3.1.

Auto-correct new Rubocop offenses caused by the the upgrade.