### PR TITLE
Use v1 tag for the semver_pr_label_check workflow

### DIFF
--- a/.github/workflows/semver_pr_label_check.yml
+++ b/.github/workflows/semver_pr_label_check.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   run_semver_pr_label_check:
-    uses: main-branch/semver_pr_label_check/.github/workflows/semver_pr_label_check.yml@main
+    uses: main-branch/semver_pr_label_check/.github/workflows/semver_pr_label_check.yml@v1
     secrets:
       repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the semver_pr_label_check workflow via the v1 tag instead of the latest on the main branch so that breaking changes do not break the build for this project.