### PR TITLE
Rearrange workflow definitions to have the name first

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
@@ -44,10 +45,10 @@ jobs:
         run: bundle exec rake
 
   coverage:
+    name: Report test coverage to CodeClimate
+
     needs: [build]
     runs-on: ubuntu-latest
-
-    name: Report test coverage to CodeClimate
 
     steps:
       - name: Checkout

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 


### PR DESCRIPTION
Move the `name:` field to be the first field in each job just for consistency.