### PR TITLE
Output the number of lines missing coverage

### DIFF
--- a/spec/simplecov-rspec/list_uncovered_lines.feature
+++ b/spec/simplecov-rspec/list_uncovered_lines.feature
@@ -1,5 +1,18 @@
 Feature: List uncovered lines
-  Scenario: Output the uncovered lines report
+  Scenario: Output the uncovered lines report (for a single lines)
+    Given the code coverage is below the threshold
+    And list_uncovered_lines? is true
+    And the following lines are missing coverage:
+      | File     | Line |
+      | file1.rb | 1    |
+    When the at_exit_hook is called
+    Then stderr output should include:
+      """
+      1 line is not covered by tests:
+        ./file1.rb:1
+      """
+
+  Scenario: Output the uncovered lines report (>1 lines)
     Given the code coverage is below the threshold
     And list_uncovered_lines? is true
     And the following lines are missing coverage:
@@ -11,7 +24,7 @@ Feature: List uncovered lines
     When the at_exit_hook is called
     Then stderr output should include:
       """
-      The following lines were not covered by tests:
+      4 lines are not covered by tests:
         ./file1.rb:1
         ./file1.rb:2
         ./file2.rb:3
@@ -21,12 +34,11 @@ Feature: List uncovered lines
   Scenario: When the uncovered lines report was requested but there were no uncovered lines
     Given the code coverage is below the threshold
     And list_uncovered_lines? is true
-    And the following lines are missing coverage:
-      | File     | Line |
+    And no lines are missing coverage
     When the at_exit_hook is called
     Then stderr output should NOT include:
       """
-      The following lines were not covered by tests:
+      lines were not covered by tests:
       """
 
   Scenario: There were uncovered lines but the uncovered lines report was not requested
@@ -39,5 +51,5 @@ Feature: List uncovered lines
     When the at_exit_hook is called
     Then stderr output should NOT include:
       """
-      The following lines were not covered by tests:
+      lines were not covered by tests:
       """

--- a/spec/simplecov-rspec/rspec_cucumber_steps.rb
+++ b/spec/simplecov-rspec/rspec_cucumber_steps.rb
@@ -102,6 +102,10 @@ step 'the following lines are missing coverage:' do |table|
   end
 end
 
+step 'no lines are missing coverage' do
+  @files_with_low_coverage = []
+end
+
 step 'the at_exit_hook is called' do
   capture_command_result do
     @rspec_result_processor.send(:at_exit_hook).call


### PR DESCRIPTION
When outputting the lines not covered by tests, show the count.

This PR changes this output:
```
The following lines were not covered by tests:
  ./file1.rb:1
  ./file1.rb:2
  ./file2.rb:3
  ./file3.rb:4
```

To this:
```
1 line is not covered by tests:
  ./file1.rb:1
```

Or:
```
4 lines are not covered by tests:
  ./file1.rb:1
  ./file1.rb:2
  ./file2.rb:3
  ./file3.rb:4
```