### PR TITLE
Document why the JRuby --debug flag is being set

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,6 +10,8 @@ on:
   workflow_dispatch:
 
 env:
+  # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
+  # results from JRuby are complete.
   JRUBY_OPTS: --debug
 
 # Supported platforms / Ruby versions:

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -7,6 +7,8 @@ on:
   workflow_dispatch:
 
 env:
+  # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
+  # results from JRuby are complete.
   JRUBY_OPTS: --debug
 
 # Experimental platforms / Ruby versions:


### PR DESCRIPTION
SimpleCov suggests using the `--debug` option in to ensure that code coverage is reported correctly.

This PR adds a comment when JRUBY_OPTS is set.