### PR TITLE
Fix the YARD doc generation to use the correct license file name

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -3,4 +3,4 @@
 --markup-provider=redcarpet
 --markup markdown
 - CHANGELOG.md
-- LICENSE.md
+- LICENSE.txt


### PR DESCRIPTION
Change the license file name from LICENSE.md to (correct) LICENSE.txt.