### PR TITLE
Remove unneeded --exclude options in .yardopts

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -2,7 +2,6 @@
 --hide-void-return
 --markup-provider=redcarpet
 --markup markdown
---exclude examples/**
 - CHANGELOG.md
 - CONTRIBUTING.md
 - RELEASING.md


### PR DESCRIPTION
The excluded directory (examples/**) is not included by default.