### PR TITLE
Use shared Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,37 +1,5 @@
-AllCops:
-  NewCops: enable
-  SuggestExtensions: false
-  DefaultFormatter: fuubar
-
-  # Output extra information for each offense to make it easier to diagnose:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  ExtraDetails: true
-
-  # RuboCop enforces rules depending on the oldest version of Ruby which
-  # your project supports:
-  TargetRubyVersion: 3.1
-
-Gemspec/DevelopmentDependencies:
-  Enabled: false
-
-Layout/LineLength:
-  Max: 120
-
-# The DSL for RSpec and the gemspec file make it very hard to limit block length
-Metrics/BlockLength:
-  Exclude:
-    - '**/*_spec.rb'
-    - '*.gemspec'
-
-Metrics/ModuleLength:
-  CountAsOne: ['hash']
-
-Metrics/ClassLength:
-  CountAsOne: ['hash']
-
-Style/AsciiComments:
-  Enabled: false
+inherit_gem:
+  main_branch_shared_rubocop_config: config/rubocop.yml
 
 Style/StderrPuts:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -44,14 +44,9 @@ CLEAN << 'rspec-report.xml'
 
 require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new do |t|
-  t.options = %w[
-    --format progress
-    --format json --out rubocop-report.json
-  ]
-end
+RuboCop::RakeTask.new
 
-CLEAN << 'rubocop-report.json'
+# YARD
 
 unless RUBY_PLATFORM == 'java'
   # yard:build

--- a/simplecov-rspec.gemspec
+++ b/simplecov-rspec.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'create_github_release', '~> 1.5'
   spec.add_development_dependency 'fuubar', '~> 2.5'
+  spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.66'


### PR DESCRIPTION
Update the .rubocop.yml to inherit from a shared Rubocop config from the main_branch_shared_rubocop_config gem.