### PR TITLE
Add TargetRubyVersion in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,11 @@
 inherit_gem:
   main_branch_shared_rubocop_config: config/rubocop.yml
 
+AllCops:
+  # RuboCop enforces rules depending on the oldest version of Ruby which
+  # your project supports:
+  TargetRubyVersion: 3.1
+
 Style/StderrPuts:
   Enabled: false
 


### PR DESCRIPTION
Need to add the TargetRubyVersion so this project can stay on Ruby 3.1 even if the shared config is updated to 3.2.