### PR TITLE
build: update create_github_release dependency

### DIFF
--- a/simplecov-rspec.gemspec
+++ b/simplecov-rspec.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'simplecov', '~> 0.22'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'create_github_release', '~> 1.5'
+  spec.add_development_dependency 'create_github_release', '~> 2.1'
   spec.add_development_dependency 'fuubar', '~> 2.5'
   spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.2'


### PR DESCRIPTION
Update the version of create_github_release
to one that does a valid conventional commit
for the release commit.