### PR TITLE
Refactor CI configuration and remove Code Climate integration

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -48,27 +48,3 @@ jobs:
 
       - name: Run rake
         run: bundle exec rake
-
-  coverage:
-    name: Report test coverage to CodeClimate
-
-    needs: [build]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Initialize Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.1
-          bundler-cache: true
-
-      - name: Report test coverage
-        uses: paambaati/codeclimate-action@v9
-        env:
-          CC_TEST_REPORTER_ID: ddf1b66251c781daaf3d2b44371e7040ce4a60126bc0c270855f8bee2c58d6d1
-        with:
-          coverageCommand: bundle exec rake spec
-          coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/simplecov-rspec/)
 [![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/simplecov-rspec/file/CHANGELOG.md)
 [![Build Status](https://github.com/main-branch/simplecov-rspec/actions/workflows/continuous_integration.yml/badge.svg)](https://github.com/main-branch/simplecov-rspec/actions/workflows/continuous_integration.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/9a58b51d18910db724c7/maintainability)](https://codeclimate.com/github/main-branch/simplecov-rspec/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/9a58b51d18910db724c7/test_coverage)](https://codeclimate.com/github/main-branch/simplecov-rspec/test_coverage)
 [![Conventional
 Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Slack](https://img.shields.io/badge/slack-main--branch/simplecov--rspec-yellow.svg?logo=slack)](https://main-branch.slack.com/archives/C07MCM9J72B)
@@ -34,12 +32,12 @@ If configured to list the lines that were not covered by tests, RSpec will addit
 
 * [Installation](#installation)
 * [Getting started](#getting-started)
-  * [Basic setup](#basic-setup)
-  * [Configuration from environment variables](#configuration-from-environment-variables)
+    * [Basic setup](#basic-setup)
+    * [Configuration from environment variables](#configuration-from-environment-variables)
 * [Development](#development)
 * [Contributing](#contributing)
-  * [Commit message guidelines](#commit-message-guidelines)
-  * [Pull request guidelines](#pull-request-guidelines)
+    * [Commit message guidelines](#commit-message-guidelines)
+    * [Pull request guidelines](#pull-request-guidelines)
 * [License](#license)
 * [Code of conduct](#code-of-conduct)
 

--- a/lib/simplecov-rspec.rb
+++ b/lib/simplecov-rspec.rb
@@ -231,6 +231,21 @@ module SimpleCov
     #
     def rspec_dry_run? = @rspec_dry_run
 
+    # An uncovered line
+    #
+    # @!attribute project_filename [rw]
+    #   The path to the file with uncovered lines relative to the project root
+    #   @return [String]
+    #   @api private
+    #
+    # @!attribute line_number [rw]
+    #   The line number of the uncovered line
+    #   @return [Integer]
+    #   @api private
+    #
+    # @api private
+    UncoveredLine = Struct.new(:project_filename, :line_number)
+
     private
 
     # rubocop:disable Metrics/ParameterLists
@@ -322,21 +337,6 @@ module SimpleCov
     # @api private
     # @private
     def show_uncovered_lines_report? = list_uncovered_lines? && uncovered_lines_found?
-
-    # An uncovered line
-    #
-    # @!attribute project_filename [rw]
-    #   The path to the file with uncovered lines relative to the project root
-    #   @return [String]
-    #   @api private
-    #
-    # @!attribute line_number [rw]
-    #   The line number of the uncovered line
-    #   @return [Integer]
-    #   @api private
-    #
-    # @api private
-    UncoveredLine = Struct.new(:project_filename, :line_number)
 
     # Return the uncovered lines from the SimpleCov result
     # @return [Array<UncoveredLine>]


### PR DESCRIPTION
Adjust the CI configuration to only fail non-Windows MRI builds for low test coverage and streamline the UncoveredLine struct definition. Remove Code Climate integration from the documentation.